### PR TITLE
assertSame fix linting

### DIFF
--- a/src/ArrayAssertsTrait.php
+++ b/src/ArrayAssertsTrait.php
@@ -100,9 +100,9 @@ trait ArrayAssertsTrait
      *
      * Ensures this method must be provided by classes using this trait.
      *
-     * @param string $expected The expected value.
-     * @param mixed  $actual   The actual value.
-     * @param string $message  Optional error message to give upon failure.
+     * @param string|array|object $expected The expected value.
+     * @param mixed               $actual   The actual value.
+     * @param string              $message  Optional error message to give upon failure.
      *
      * @return void
      */


### PR DESCRIPTION
#### What does this PR do?

Assert Same method no longer lints poorly if the object is an array or an object.

#### Checklist
- [x] Pull request contains a clear definition of changes
- [x] Tests (either unit, integration, or acceptance) written and passing
- [x] Relevant documentation produced and/or updated
